### PR TITLE
increase flexibility in the flodym array setitem and set_values methods

### DIFF
--- a/howtos/04_arrays.ipynb
+++ b/howtos/04_arrays.ipynb
@@ -300,8 +300,31 @@
    "source": [
     "sum_with_scalar = flow_a + 0.4\n",
     "\n",
-    "print(\"SUm with scalar:\")\n",
+    "print(\"Sum with scalar:\")\n",
     "show_array(sum_with_scalar)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73cb58cc",
+   "metadata": {},
+   "source": [
+    "### using the apply method\n",
+    "For math operations on a single array, you can use the `FlodymArray.apply()` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fc03673",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "log_flow_a = flow_a.apply(np.log)\n",
+    "print(\"Log of flow_a:\")\n",
+    "show_array(log_flow_a)"
    ]
   },
   {
@@ -311,7 +334,8 @@
    "source": [
     "### Using just the `values` array\n",
     "\n",
-    "When a mathematical operation is not implemented, you can still work with the `values` array manually, which is a numpy array. We recommend using either the numpy ellipsis slice `[...]` or the `FlodymArray.set_values()` method, which both ensure keeping the correct shape of the array."
+    "When a mathematical operation is not implemented, you can still work with the `values` array manually, which is a numpy array.\n",
+    "We recommend using either the numpy ellipsis slice `[...]` or the `FlodymArray.set_values()` method, which both ensure keeping the correct shape of the array."
    ]
   },
   {
@@ -501,6 +525,18 @@
     "flows[\"predefined_flow\"] = flows[\"flow_a\"] * parameters[\"parameter_a\"]\n",
     "print(\"WRONG predefined_flow:\")\n",
     "show_array(flows[\"predefined_flow\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aadefd28",
+   "metadata": {},
+   "source": [
+    "If you perform an operation of the form `flow_a[...] = foo`,\n",
+    "`foo` can be a FlodymArray, a numpy array or a scalar.\n",
+    "Whenever possible, is is safest if `foo` is a FlodymArray.\n",
+    "While the above code will check for the correct shape of foo even if it is a numpy array,\n",
+    "it will not, for example, recognize, if two dimensions of the same size are swapped in `foo`."
    ]
   },
   {

--- a/howtos/04_arrays.py
+++ b/howtos/04_arrays.py
@@ -116,13 +116,24 @@ show_array(reduced)
 # %%
 sum_with_scalar = flow_a + 0.4
 
-print("SUm with scalar:")
+print("Sum with scalar:")
 show_array(sum_with_scalar)
+
+# %% [markdown]
+# ### using the apply method
+# For math operations on a single array, you can use the `FlodymArray.apply()` method.
+
+# %%
+log_flow_a = flow_a.apply(np.log)
+print("Log of flow_a:")
+show_array(log_flow_a)
+
 
 # %% [markdown]
 # ### Using just the `values` array
 #
-# When a mathematical operation is not implemented, you can still work with the `values` array manually, which is a numpy array. We recommend using either the numpy ellipsis slice `[...]` or the `FlodymArray.set_values()` method, which both ensure keeping the correct shape of the array.
+# When a mathematical operation is not implemented, you can still work with the `values` array manually, which is a numpy array.
+# We recommend using either the numpy ellipsis slice `[...]` or the `FlodymArray.set_values()` method, which both ensure keeping the correct shape of the array.
 
 # %%
 flow_a.values[...] = 0.3
@@ -187,6 +198,13 @@ show_array(flows["predefined_flow"])
 flows["predefined_flow"] = flows["flow_a"] * parameters["parameter_a"]
 print("WRONG predefined_flow:")
 show_array(flows["predefined_flow"])
+
+# %% [markdown]
+# If you perform an operation of the form `flow_a[...] = foo`,
+# `foo` can be a FlodymArray, a numpy array or a scalar.
+# Whenever possible, is is safest if `foo` is a FlodymArray.
+# While the above code will check for the correct shape of foo even if it is a numpy array,
+# it will not, for example, recognize, if two dimensions of the same size are swapped in `foo`.
 
 # %% [markdown]
 # ## Slicing


### PR DESCRIPTION
## Purpose of this PR

Allow the following new syntaxes, where `foo` is a flodym array: 

- `foo[...] = bar`, where `bar` is a numpy array or a scalar
- `foo.set_values(bar)`, where `bar` is a scalar

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] New feature

## Checklist:

- [x] I have updated the in-code documentation of all changed classes and functions
- [x] I have added in-code documentation and type hints to all new classes and functions
- [x] I have adapted the howtos
- [x] I have adapted the examples
- [x] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
