### PR TITLE
Change DimensionSet.shape method to property

### DIFF
--- a/flodym/_df_to_flodym_array.py
+++ b/flodym/_df_to_flodym_array.py
@@ -251,7 +251,7 @@ class DataFrameToFlodymDataConverter:
         fill_indices = self.df.values[:, :-1].T.astype(np.int16)
         fill_values = self.df[self.format.value_column].values
         # this is what ends up in the parameter; initialize with zeros
-        values = np.zeros(self.flodym_array.dims.shape())
+        values = np.zeros(self.flodym_array.dims.shape)
         values[tuple(fill_indices)] = fill_values
         return values
 

--- a/flodym/dimensions.py
+++ b/flodym/dimensions.py
@@ -182,7 +182,7 @@ class DimensionSet(PydanticBaseModel):
 
     @property
     def shape(self) -> tuple[int]:
-        """shape of the array that would be created with the dimensions in the set """
+        """shape of the array that would be created with the dimensions in the set"""
         return tuple(self.size(dim) for dim in self.letters)
 
     @property

--- a/flodym/dimensions.py
+++ b/flodym/dimensions.py
@@ -180,14 +180,10 @@ class DimensionSet(PydanticBaseModel):
         """
         return self._dict[key].len
 
-    def shape(self, keys: tuple = None):
-        """get the shape of the array that would be created with the dimensions in the set
-
-        Args:
-            keys (tuple, optional): the names or letters of the dimensions to get the shape of. If None, all dimensions are used. Defaults to None.
-        """
-        keys = keys if keys else self.letters
-        return tuple(self.size(key) for key in keys)
+    @property
+    def shape(self) -> tuple[int]:
+        """shape of the array that would be created with the dimensions in the set """
+        return tuple(self.size(dim) for dim in self.letters)
 
     @property
     def ndim(self):

--- a/flodym/flodym_arrays.py
+++ b/flodym/flodym_arrays.py
@@ -64,7 +64,7 @@ class FlodymArray(PydanticBaseModel):
     @model_validator(mode="after")
     def validate_values(self):
         if self.values is None:
-            self.values = np.zeros(self.dims.shape())
+            self.values = np.zeros(self.dims.shape)
         self._check_value_format()
         return self
 
@@ -76,10 +76,10 @@ class FlodymArray(PydanticBaseModel):
         elif self.dims.ndim == 0 and isinstance(self.values, np.generic):
             self.values = np.array(self.values)
 
-        if self.values.shape != self.dims.shape():
+        if self.values.shape != self.dims.shape:
             raise ValueError(
                 f"Values passed to {self.__class__.__name__} must have the same shape as the DimensionSet.\n"
-                f"Array shape: {self.dims.shape()}\n"
+                f"Array shape: {self.dims.shape}\n"
                 f"Values shape: {self.values.shape}\n"
             )
 
@@ -148,7 +148,7 @@ class FlodymArray(PydanticBaseModel):
     @property
     def shape(self) -> tuple[int]:
         """The shape of the array, determined by the dimensions."""
-        return self.dims.shape()
+        return self.dims.shape
 
     @property
     def size(self) -> int:

--- a/flodym/lifetime_models.py
+++ b/flodym/lifetime_models.py
@@ -26,7 +26,7 @@ class LifetimeModel(PydanticBaseModel):
 
     @property
     def shape(self):
-        return self.dims.shape()
+        return self.dims.shape
 
     @property
     def _n_t(self):

--- a/flodym/stocks.py
+++ b/flodym/stocks.py
@@ -83,7 +83,7 @@ class Stock(PydanticBaseModel):
     @property
     def shape(self) -> tuple:
         """Shape of the stock, inflow, outflow arrays, defined by the dimensions."""
-        return self.dims.shape()
+        return self.dims.shape
 
     @property
     def process_id(self) -> int:

--- a/howtos/04_arrays.ipynb
+++ b/howtos/04_arrays.ipynb
@@ -98,7 +98,7 @@
    "source": [
     "def show_array(arr: FlodymArray):\n",
     "    print(f\"  dimensions: {arr.dims.letters}\")\n",
-    "    print(f\"  shape: {arr.dims.shape()}\")\n",
+    "    print(f\"  shape: {arr.dims.shape}\")\n",
     "    print(f\"  name: {arr.name}\")\n",
     "    print(f\"  values mean: {np.mean(arr.values):.3f}\")\n",
     "    print(f\"  values sum: {arr.values.sum():.3f}\")\n",

--- a/howtos/04_arrays.py
+++ b/howtos/04_arrays.py
@@ -48,7 +48,7 @@ parameter_a = FlodymArray(dims=dims["r", "p"], values=0.5 * np.ones((3, 2)))
 # %%
 def show_array(arr: FlodymArray):
     print(f"  dimensions: {arr.dims.letters}")
-    print(f"  shape: {arr.dims.shape()}")
+    print(f"  shape: {arr.dims.shape}")
     print(f"  name: {arr.name}")
     print(f"  values mean: {np.mean(arr.values):.3f}")
     print(f"  values sum: {arr.values.sum():.3f}")

--- a/howtos/06_stocks.ipynb
+++ b/howtos/06_stocks.ipynb
@@ -176,7 +176,7 @@
     "from flodym import StockArray\n",
     "\n",
     "lifetime_model = NormalLifetime(dims=dims, mean=lifetime_mean, std=0.3 * lifetime_mean)\n",
-    "inflow = StockArray(dims=dims, name=\"in-use-dsm_inflows\", values=0.1 * np.ones(dims.shape()))\n",
+    "inflow = StockArray(dims=dims, name=\"in-use-dsm_inflows\", values=0.1 * np.ones(dims.shape))\n",
     "my_dsm = InflowDrivenDSM(\n",
     "    dims=dims,\n",
     "    name=\"in-use-dsm\",\n",

--- a/howtos/06_stocks.py
+++ b/howtos/06_stocks.py
@@ -89,7 +89,7 @@ print("Stock values for Vehicles:", my_dsm.stock["Vehicles"].values)
 from flodym import StockArray
 
 lifetime_model = NormalLifetime(dims=dims, mean=lifetime_mean, std=0.3 * lifetime_mean)
-inflow = StockArray(dims=dims, name="in-use-dsm_inflows", values=0.1 * np.ones(dims.shape()))
+inflow = StockArray(dims=dims, name="in-use-dsm_inflows", values=0.1 * np.ones(dims.shape))
 my_dsm = InflowDrivenDSM(
     dims=dims,
     name="in-use-dsm",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -26,7 +26,7 @@ def test_flodym_array_stack(new_dim_length):
     additional_dim = Dimension(name="extra", letter="x", items=list(range(new_dim_length)))
     stacked = flodym_array_stack(flodym_arrays, additional_dim)
 
-    assert stacked.shape[:-1] == dimension_set.shape()
+    assert stacked.shape[:-1] == dimension_set.shape
     assert stacked.dims.dim_list[:-1] == dimension_set.dim_list
 
     for i in range(new_dim_length):


### PR DESCRIPTION
## Purpose of this PR

Syntax changes from `dims.shape()` to `dims.shape`, which is consistent with the according properties of flodym arrays.
The potential parameter of the function can be realized with a square bracket, so no convenience is lost. 
Former: `dims.shape(('t', 'r'))`; Now: `dims['t', 'r'].shape`.

**CAUTION: This PR breaks backwards compatibility.**
We should inform all currently known users before merging. 

## Type of change

(Make sure to delete from the Type-of-change list the items not relevant to your PR)

- [x] Minor change

## Checklist:

- [x] I have updated the in-code documentation of all changed classes and functions
- [x] I have added in-code documentation and type hints to all new classes and functions
- [x] I have adapted the howtos
- [x] I have adapted the examples
- [x] If this change should entail a version update, I have bumped the version in the `pyproject.toml` file accordingly
- [x] All users informed about break in backwards compatibility